### PR TITLE
Match pattern when infering model on pipeline of preload and all queries

### DIFF
--- a/lib/new_relic/plug/instrumentation.ex
+++ b/lib/new_relic/plug/instrumentation.ex
@@ -61,6 +61,10 @@ defmodule NewRelic.Plug.Instrumentation do
     nil
   end
 
+  defp infer_model({_, _, [model_type | _]}) do
+    model_name(model_type)
+  end
+
   defp infer_model(queryable) do
     infer_model(Ecto.Queryable.to_query(queryable))
   end

--- a/test/new_relic/plug/repo_test.exs
+++ b/test/new_relic/plug/repo_test.exs
@@ -431,6 +431,20 @@ defmodule NewRelic.Plug.RepoTest do
     assert_between(recorded_time, sleep_time, elapsed_time)
   end
 
+  # preload and all
+
+  test "preload accepts model as first argument", %{conn: conn} do
+    assert FakeModel |> Repo.all |> Repo.preload(:foo, conn: conn) == FakeModel |> FakeRepo.all |> FakeRepo.preload(:foo)
+  end
+
+  test "preload works when passed connection and repo.all is last function called", %{conn: conn} do
+    assert FakeModel |> Repo.preload(:foo, conn: conn) |> Repo.all == FakeModel |> FakeRepo.preload(:foo) |> Repo.all
+  end
+
+  test "preload works when repo.all is last function called", %{conn: conn} do
+    assert FakeModel |> Repo.preload(:foo) |> Repo.all(conn: conn) == FakeModel |> FakeRepo.preload(:foo) |> Repo.all
+  end
+
   # transaction
 
   test "transaction calls repo's transaction method", %{conn: _conn} do


### PR DESCRIPTION
master was returning 
`** (Protocol.UndefinedError) protocol Ecto.Queryable not implemented for [%App.Model{}]` when trying to infer the model used when a combination of `Repo.all` and `Repo.preload` are used.