### PR TITLE
Treat blank environment variables as nil

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -20,6 +20,6 @@ defmodule NewRelic do
   @doc false
   @spec configured? :: boolean
   def configured? do
-    Application.get_env(:new_relic, :application_name) != nil && Application.get_env(:new_relic, :license_key) != nil
+    "#{Application.get_env(:new_relic, :application_name)}" != "" && "#{Application.get_env(:new_relic, :license_key)}" != ""
   end
 end


### PR DESCRIPTION
Consider blank variables as nil.

Useful when using `"${ENV_VARIABLE}"` way during the compile time, that is converted to `""` when no env found at run time.
