### PR TITLE
Relax Poison dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule NewRelic.Mixfile do
     [{:phoenix, "~> 1.2"},
      {:ecto, ">= 1.1.0"},
      {:lhttpc, "~> 1.4"},
-     {:poison, "~> 2.2.0"},
+     {:poison, "~> 2.2 or ~> 3.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 


### PR DESCRIPTION
Hi there,

just realized you can't use this plugin when you're using phoenix 1.3. I relaxed the dependency just as it is done in the phoenix `mix.exs` (https://github.com/phoenixframework/phoenix/blob/master/mix.exs)