### PR TITLE
Use system DNS hostname to determine current host name.

### DIFF
--- a/lib/new_relic/poller.ex
+++ b/lib/new_relic/poller.ex
@@ -28,7 +28,7 @@ defmodule NewRelic.Poller do
   def handle_info(:poll, %{poll_fun: poll_fun, error_cb: error_cb, timer: old_timer}) do
     :erlang.cancel_timer(old_timer)
     timer = :erlang.send_after(@poll_interval, self(), :poll)
-    {:ok, hostname} = :inet.gethostname()
+    {:ok, hostname} = :net_adm.dns_hostname(:net_adm.localhost)
     try do
       case poll_fun.() do
         {[], []} ->


### PR DESCRIPTION
This makes NewRelic agent hostname value and OS `hostname` command output identical and more precise. 

It also avoids issues with NewRelic licenses when different agents send data from the same host, but Ruby-agents indicate it as full hostname (e.g. `vs01.example.net`) and Elixir agents as short hostname (e.g. `vs01`). NewRelic considers these as different app hosts in term of their license.