### PR TITLE
Report to New Relic using the latest Python agent version

### DIFF
--- a/lib/new_relic/agent.ex
+++ b/lib/new_relic/agent.ex
@@ -39,7 +39,7 @@ defmodule NewRelic.Agent do
     url = url(collector, [method: :connect])
 
     data = [%{
-      :agent_version => "1.5.0.103",
+      :agent_version => "4.18.0.118",
       :app_name => [app_name()],
       :host => l2b(hostname),
       :identifier => app_name(),


### PR DESCRIPTION
Currently, the Elixir agent reports to New Relic as Python agent version 1.5.0.103. This agent version has been deprecated, and in July 2019, New Relic will begin refusing connections from this version. This PR modifies the Elixir agent to report as Python agent version 4.18.0.118, which is the latest version.