### PR TITLE
Remove compilation errors for Phoenix/Ecto not being included

### DIFF
--- a/lib/new_relic/plug/instrumentation.ex
+++ b/lib/new_relic/plug/instrumentation.ex
@@ -41,7 +41,7 @@ defmodule NewRelic.Plug.Instrumentation do
     Keyword.put_new(opts, :action, action)
   end
 
-  defp infer_model(%{__struct__: model_type, __meta__: %Ecto.Schema.Metadata{}}) do
+  defp infer_model(%{__struct__: model_type, __meta__: %{__struct__: Ecto.Schema.Metadata}}) do
     model_name(model_type)
   end
   # Ecto 1.1 clause
@@ -53,11 +53,11 @@ defmodule NewRelic.Plug.Instrumentation do
     infer_model(data)
   end
 
-  defp infer_model(%Ecto.Query{from: {_, model_type}}) do
+  defp infer_model(%{__struct__: Ecto.Query, from: {_, model_type}}) do
     model_name(model_type)
   end
 
-  defp infer_model(%Ecto.Query{}) do
+  defp infer_model(%{__struct__: Ecto.Query}) do
     nil
   end
 

--- a/lib/new_relic/plug/phoenix.ex
+++ b/lib/new_relic/plug/phoenix.ex
@@ -18,8 +18,6 @@ defmodule NewRelic.Plug.Phoenix do
   """
 
   @behaviour Elixir.Plug
-  import Elixir.Phoenix.Controller
-  import Elixir.Plug.Conn
 
   def init(opts) do
     opts
@@ -27,13 +25,13 @@ defmodule NewRelic.Plug.Phoenix do
 
   def call(conn, _config) do
     if NewRelic.configured? do
-      module = conn |> controller_module |> Module.split |> List.last
-      action = conn |> action_name |> Atom.to_string
+      module = conn |> Phoenix.Controller.controller_module |> Module.split |> List.last
+      action = conn |> Phoenix.Controller.action_name |> Atom.to_string
       transaction_name = "#{module}##{action}"
 
       conn
-      |> put_private(:new_relixir_transaction, NewRelic.Transaction.start(transaction_name))
-      |> register_before_send(fn conn ->
+      |> Plug.Conn.put_private(:new_relixir_transaction, NewRelic.Transaction.start(transaction_name))
+      |> Plug.Conn.register_before_send(fn conn ->
         NewRelic.Transaction.finish(Map.get(conn.private, :new_relixir_transaction))
 
         conn


### PR DESCRIPTION
WIP for #14 
 
There are still compilation errors with this, because the functions don't exist if the dependencies aren't there. I've solved this in the past with quoted AST in the library that gets `use`d into a module, but that probably isn't desired here. Going to think a bit more about how to get rid of these compilation errors if ecto/phoenix aren't included.